### PR TITLE
Refactor the mollie code to support the v2+ API interface.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='django-oscar-mollie',
         'mollie_oscar'
       ],
       install_requires=[
-        'mollie-api-python<1.4',
+        'mollie-api-python>=2,<4',
         'django>=2.1',
         'django-oscar>=2.1',
       ]


### PR DESCRIPTION
- Uses newest mollie-api-python client
- Uses v2 Mollie API, so no pressure to migrate to the new API

The issue that triggered this change was that the old 1.3.2 client produced a header that the Mollie API doesn't accept anymore.

For GET requests, an empty JSON body was generated (see https://github.com/mollie/mollie-api-python/blob/2e45f258fadcd3863292b89d709d41f627f7d3ff/Mollie/API/Client.py#L74), and this triggered requests (or urllib3) to produce a `Content-length: 2` header. This is incorrect since a GET request has no body, and the Mollie API apparently checks this since some time.

Rather than fixing the bug in a hard way, just upgrade.